### PR TITLE
Fix to execution order issue when using SimpleMove from Start()

### DIFF
--- a/Assets/DoNotTouch/Scripts/SimpleMove.cs
+++ b/Assets/DoNotTouch/Scripts/SimpleMove.cs
@@ -6,7 +6,7 @@ public class SimpleMove : MonoBehaviour {
 
 	[SerializeField] float speed;
 
-	private List<Vector3> displacements;
+	private List<Vector3> displacements = new List<Vector3>();
 	private int currentIndex;
 	private Vector3 currentDisplacement;
 	private Vector3 currentTarget;
@@ -14,10 +14,6 @@ public class SimpleMove : MonoBehaviour {
 	private bool hasStarted;
 	private bool hasFinished;
 	private int frameCount;
-
-	void Start() {
-		this.displacements = new List<Vector3>();
-	}
 
 	void Update() {
 		frameCount++;


### PR DESCRIPTION
Initialize SimpleMove.displacements on definition, instead of Start(), to prevent execution order issues when other scripts try to configure SimpleMove in their Start().

If that happens, the user will receive a NullRefException when trying to set a new Move.
